### PR TITLE
Destory watchers when done with them.

### DIFF
--- a/core/cache/charm.go
+++ b/core/cache/charm.go
@@ -9,8 +9,11 @@ import (
 	"github.com/juju/juju/core/lxdprofile"
 )
 
-func newCharm(metrics *ControllerGauges, hub *pubsub.SimpleHub) *Charm {
+func newCharm(metrics *ControllerGauges, hub *pubsub.SimpleHub, resources *Resources) *Charm {
 	c := &Charm{
+		entity: entity{
+			resources: resources,
+		},
 		metrics: metrics,
 		hub:     hub,
 	}
@@ -26,8 +29,9 @@ type Charm struct {
 	entity
 
 	// Link to model?
-	metrics *ControllerGauges
-	hub     *pubsub.SimpleHub
+	metrics   *ControllerGauges
+	hub       *pubsub.SimpleHub
+	resources *Resources
 
 	details CharmChange
 }
@@ -45,11 +49,6 @@ func (c *Charm) removalDelta() interface{} {
 		ModelUUID: c.details.ModelUUID,
 		CharmURL:  c.details.CharmURL,
 	}
-}
-
-// remove cleans up any associated data with the charm
-func (c *Charm) remove() {
-	// TODO (stickupkid): clean watchers
 }
 
 func (c *Charm) setDetails(details CharmChange) {

--- a/core/cache/entity.go
+++ b/core/cache/entity.go
@@ -26,7 +26,7 @@ type entity struct {
 	freshness    entityFreshness
 	mu           sync.Mutex
 	removalDelta func() interface{}
-	watchers     []Watcher
+	resources    *Resources
 }
 
 // mark updates the state to be classified as stale.
@@ -61,6 +61,11 @@ func (e *entity) sweep() (*SweepDeltas, error) {
 	return &SweepDeltas{
 		FreshCount: 1,
 	}, nil
+}
+
+// remove cleans up any associated data with the entity
+func (e *entity) remove() error {
+	return e.resources.StopAll()
 }
 
 // SweepInfo represents the information gathered whilst doing a sweep

--- a/core/cache/resources.go
+++ b/core/cache/resources.go
@@ -1,0 +1,120 @@
+// Copyright 2019 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cache
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/juju/errors"
+	worker "gopkg.in/juju/worker.v1"
+)
+
+type identifier struct {
+	counter uint64
+}
+
+func newIdentifier() *identifier {
+	return &identifier{counter: 0}
+}
+
+func (id *identifier) Inc() uint64 {
+	return atomic.AddUint64(&id.counter, 1)
+}
+
+type Resources struct {
+	identifier   *identifier
+	subResources map[string]*Resources
+	watchers     map[uint64]Watcher
+	mu           sync.Mutex
+}
+
+func newResources(identifier *identifier) *Resources {
+	return &Resources{
+		identifier:   identifier,
+		subResources: make(map[string]*Resources),
+		watchers:     make(map[uint64]Watcher),
+	}
+}
+
+func (r *Resources) Namespace(ns string) *Resources {
+	if _, ok := r.subResources[ns]; !ok {
+		r.subResources[ns] = newResources(r.identifier)
+	}
+	return r.subResources[ns]
+}
+
+// Register a watcher to the watcher resource, which returns a uint64 for
+// identifying the watcher uniquely.
+func (r *Resources) Register(w Watcher) uint64 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	value := r.identifier.Inc()
+	r.watchers[value] = w
+	return value
+}
+
+// Unregister removes the watcher identifier from the watcher resource, but it
+// makes no effort to clean up the watcher itself
+func (r *Resources) Unregister(identifier uint64) {
+	r.mu.Lock()
+	delete(r.watchers, identifier)
+	r.mu.Unlock()
+}
+
+// Stop attempts to stop a watcher with in the resources.
+func (r *Resources) Stop(identifier uint64) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// attempt to search over your own resources before going through the
+	// subresources
+	for id, watcher := range r.watchers {
+		if id == identifier {
+			if err := worker.Stop(watcher); err != nil {
+				return errors.Trace(err)
+			}
+			return nil
+		}
+	}
+	for _, subResource := range r.subResources {
+		err := subResource.Stop(identifier)
+		// we stopped the resource, so no need to walk any further
+		if err == nil {
+			return nil
+		}
+		// we didn't find anything, so we need to continue walking
+		if errors.IsNotFound(err) {
+			continue
+		}
+		// we found an error attempting to stop the resource, so we should
+		// bubble the error up.
+		return errors.Trace(err)
+	}
+	return errors.NotFoundf("watcher for identifier %d", identifier)
+}
+
+// StopAll attempts to stop all the watchers with in the resources, which
+// includes all the sub-resources with in the namespaces doing a bottom cleanup
+// effectively.
+// StopAll will also unregister the watcher at the same time.
+func (r *Resources) StopAll() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for namespace, subResource := range r.subResources {
+		if err := subResource.StopAll(); err != nil {
+			return errors.Trace(err)
+		}
+		delete(r.subResources, namespace)
+	}
+	for identifier, watcher := range r.watchers {
+		if err := worker.Stop(watcher); err != nil {
+			return errors.Trace(err)
+		}
+		delete(r.watchers, identifier)
+	}
+	return nil
+}

--- a/core/cache/unit.go
+++ b/core/cache/unit.go
@@ -18,8 +18,11 @@ type Unit struct {
 	configHash string
 }
 
-func newUnit(metrics *ControllerGauges, hub *pubsub.SimpleHub) *Unit {
+func newUnit(metrics *ControllerGauges, hub *pubsub.SimpleHub, resources *Resources) *Unit {
 	u := &Unit{
+		entity: entity{
+			resources: resources,
+		},
 		metrics: metrics,
 		hub:     hub,
 	}
@@ -43,11 +46,6 @@ func (u *Unit) removalDelta() interface{} {
 		ModelUUID: u.details.ModelUUID,
 		Name:      u.details.Name,
 	}
-}
-
-// remove cleans up any associated data with the unit
-func (u *Unit) remove() {
-	// TODO (stickupkid): clean watchers
 }
 
 func (u *Unit) setDetails(details UnitChange) {

--- a/core/cache/watcher.go
+++ b/core/cache/watcher.go
@@ -194,6 +194,10 @@ func (w *stringsWatcherBase) Changes() <-chan []string {
 func (w *stringsWatcherBase) Kill() {
 	w.mu.Lock()
 	w.closed = true
+	if w.closed {
+		w.mu.Unlock()
+		return
+	}
 	close(w.changes)
 	w.mu.Unlock()
 	w.tomb.Kill(nil)


### PR DESCRIPTION
Initial idea, would like feedback.

## Description of change

The following attempts to manage watchers as resources. Similar
to the apiserver resources, but instead this set of resources is
a tree of resources, so we can kill off watchers smartly.