### PR TITLE
Warning message when using unreleased series

### DIFF
--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
+	coreseries "github.com/juju/juju/core/series"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
@@ -217,8 +218,8 @@ type bootstrapTest struct {
 func (s *BootstrapSuite) patchVersionAndSeries(c *gc.C, hostSeries string) {
 	resetJujuXDGDataHome(c)
 	s.PatchValue(&series.MustHostSeries, func() string { return hostSeries })
-	s.PatchValue(&supportedJujuSeries, func(time.Time) (set.Strings, error) {
-		return set.NewStrings(hostSeries).Union(defaultSupportedJujuSeries), nil
+	s.PatchValue(&supportedJujuSeries, func(time.Time, string) (set.Strings, coreseries.SeriesWindow, error) {
+		return set.NewStrings(hostSeries).Union(defaultSupportedJujuSeries), coreseries.Unknown, nil
 	})
 	s.patchVersion(c)
 }
@@ -1312,8 +1313,8 @@ func (s *BootstrapSuite) setupAutoUploadTest(c *gc.C, vers, ser string) {
 	// so we can test that an upload is forced.
 	s.PatchValue(&jujuversion.Current, version.MustParse(vers))
 	s.PatchValue(&series.MustHostSeries, func() string { return ser })
-	s.PatchValue(&supportedJujuSeries, func(time.Time) (set.Strings, error) {
-		return set.NewStrings(ser).Union(defaultSupportedJujuSeries), nil
+	s.PatchValue(&supportedJujuSeries, func(time.Time, string) (set.Strings, coreseries.SeriesWindow, error) {
+		return set.NewStrings(ser).Union(defaultSupportedJujuSeries), coreseries.Unknown, nil
 	})
 
 	// Create home with dummy provider and remove all


### PR DESCRIPTION
## Description of change

To help provide context when bootstrapping a series that may not exist,
we can provide information to the operator to decide if they should take
action with setting the image-stream config correctly.

This is a follow on from https://github.com/juju/juju/pull/11332

## QA steps

See: https://github.com/juju/juju/pull/11332

```sh
juju bootstrap lxd systemd-test-focal2 --bootstrap-series focal
```

See the following warning presented to the user:

```sh
WARNING Bootstrap series "focal" is not yet supported, ensure you set image-stream config correctly.
Creating Juju controller "systemd-test-focal2" on lxd/default
Looking for packaged Juju agent version 2.7.5 for amd64
No packaged binary found, preparing local Juju agent binary
To configure your system to better support LXD containers, please see: https://github.com/lxc/lxd/blob/master/doc/production-setup.md
Launching controller instance(s) on lxd/default...
ERROR failed to bootstrap model: cannot start bootstrap instance in availability zone "simon": no matching image found
```

## Documentation changes

Warn the user around using new releases.

## Bug reference

https://bugs.launchpad.net/juju/+bug/1866320
