### PR TITLE
chore: expose metrics to the perf worker

### DIFF
--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -1060,6 +1060,7 @@ func (a *MachineAgent) startModelWorkers(cfg modelworkermanager.NewModelConfig) 
 		NewEnvironFunc:              newEnvirons,
 		NewContainerBrokerFunc:      newCAASBroker,
 		NewMigrationMaster:          migrationmaster.NewWorker,
+		PrometheusRegisterer:        cfg.PrometheusRegisterer,
 		StateTracker:                cfg.StateTracker,
 	}
 	if wrench.IsActive("charmrevision", "shortinterval") {

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -673,16 +673,17 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		},
 
 		modelWorkerManagerName: ifFullyUpgraded(modelworkermanager.Manifold(modelworkermanager.ManifoldConfig{
-			AgentName:      agentName,
-			AuthorityName:  certificateWatcherName,
-			StateName:      stateName,
-			SyslogName:     syslogName,
-			Clock:          config.Clock,
-			MuxName:        httpServerArgsName,
-			NewWorker:      modelworkermanager.New,
-			NewModelWorker: config.NewModelWorker,
-			ModelMetrics:   config.DependencyEngineMetrics,
-			Logger:         loggo.GetLogger("juju.workers.modelworkermanager"),
+			AgentName:            agentName,
+			AuthorityName:        certificateWatcherName,
+			StateName:            stateName,
+			SyslogName:           syslogName,
+			Clock:                config.Clock,
+			MuxName:              httpServerArgsName,
+			NewWorker:            modelworkermanager.New,
+			NewModelWorker:       config.NewModelWorker,
+			ModelMetrics:         config.DependencyEngineMetrics,
+			Logger:               loggo.GetLogger("juju.workers.modelworkermanager"),
+			PrometheusRegisterer: config.PrometheusRegisterer,
 		})),
 
 		peergrouperName: ifFullyUpgraded(peergrouper.Manifold(peergrouper.ManifoldConfig{

--- a/cmd/jujud/agent/model/manifolds.go
+++ b/cmd/jujud/agent/model/manifolds.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/utils/v3/voyeur"
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/dependency"
+	"github.com/prometheus/client_golang/prometheus"
 
 	coreagent "github.com/juju/juju/agent"
 	"github.com/juju/juju/api"
@@ -134,6 +135,10 @@ type ManifoldsConfig struct {
 	// worker.
 	NewMigrationMaster func(migrationmaster.Config) (worker.Worker, error)
 
+	// PrometheusRegisterer is a prometheus.Registerer that may be used
+	// by workers to register Prometheus metric collectors.
+	PrometheusRegisterer prometheus.Registerer
+
 	StateTracker workerstate.StateTracker
 }
 
@@ -228,10 +233,11 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		},
 
 		perfWorkerName: perf.Manifold(perf.ManifoldConfig{
-			AgentName: agentName,
-			Clock:     config.Clock,
-			Logger:    config.LoggingContext.GetLogger("juju.worker.perf"),
-			StateName: stateName,
+			AgentName:            agentName,
+			Clock:                config.Clock,
+			Logger:               config.LoggingContext.GetLogger("juju.worker.perf"),
+			StateName:            stateName,
+			PrometheusRegisterer: config.PrometheusRegisterer,
 		}),
 
 		// The migration workers collaborate to run migrations;

--- a/worker/modelworkermanager/modelworkermanager_test.go
+++ b/worker/modelworkermanager/modelworkermanager_test.go
@@ -189,15 +189,17 @@ func (s *suite) runKillTest(c *gc.C, kill killFunc, test testFunc) {
 	watcher := newMockModelWatcher()
 	controller := newMockController()
 	config := modelworkermanager.Config{
-		Authority:      s.authority,
-		Clock:          clock.WallClock,
-		Logger:         loggo.GetLogger("test"),
-		MachineID:      "1",
-		ModelWatcher:   watcher,
-		Controller:     controller,
-		NewModelWorker: s.startModelWorker,
-		ModelMetrics:   dummyModelMetrics{},
-		ErrorDelay:     time.Millisecond,
+		Authority:            s.authority,
+		Clock:                clock.WallClock,
+		Logger:               loggo.GetLogger("test"),
+		MachineID:            "1",
+		ModelWatcher:         watcher,
+		Controller:           controller,
+		NewModelWorker:       s.startModelWorker,
+		ModelMetrics:         dummyModelMetrics{},
+		ErrorDelay:           time.Millisecond,
+		StateTracker:         nil,
+		PrometheusRegisterer: nil,
 	}
 	w, err := modelworkermanager.New(config)
 	c.Assert(err, jc.ErrorIsNil)

--- a/worker/perf/metrics.go
+++ b/worker/perf/metrics.go
@@ -1,0 +1,40 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package perf
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	metricsNamespace   = "juju"
+	subsystemNamespace = "perf"
+)
+
+type Collector struct {
+	iterationCount prometheus.Counter
+}
+
+func NewMetricsCollector() *Collector {
+	// TODO (jam): we could use a CounterVec and do something like counts per model, but for now, we just
+	//  want to know the total count
+	return &Collector{
+		iterationCount: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: subsystemNamespace,
+			Name:      "iteration_count",
+			Help:      "Count the number of iterations that this perf worker has completed",
+		}),
+	}
+}
+
+// Describe is part of the prometheus.Collector interface.
+func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
+	c.iterationCount.Describe(ch)
+}
+
+// Collect is part of the prometheus.Collector interface.
+func (c *Collector) Collect(ch chan<- prometheus.Metric) {
+	c.iterationCount.Collect(ch)
+}

--- a/worker/perf/worker.go
+++ b/worker/perf/worker.go
@@ -26,6 +26,7 @@ type perfWorker struct {
 	runner   *worker.Runner
 	clock    clock.Clock
 	logger   Logger
+	metrics  *Collector
 
 	id int64
 
@@ -34,13 +35,14 @@ type perfWorker struct {
 	state       *state.State
 }
 
-func newPerfWorker(modelUUID string, systemState, state *state.State, clock clock.Clock, logger Logger) (*perfWorker, error) {
+func newPerfWorker(modelUUID string, systemState, state *state.State, clock clock.Clock, logger Logger, collector *Collector) (*perfWorker, error) {
 	w := &perfWorker{
 		modelUUID:   modelUUID,
 		clock:       clock,
 		logger:      logger,
 		systemState: systemState,
 		state:       state,
+		metrics:     collector,
 		runner: worker.NewRunner(worker.RunnerParams{
 			Clock: clock,
 			IsFatal: func(err error) bool {
@@ -120,6 +122,9 @@ func (w *perfWorker) run() error {
 }
 
 func (w *perfWorker) runStep(step int) error {
+	// TODO (jam): we could add metrics for the time for each of these calls to complete,
+	//  it might be interesting if one of them is particularly more expensive/slow than the others
+	w.metrics.iterationCount.Inc()
 	switch step % 6 {
 	case 1:
 		// Controller access.


### PR DESCRIPTION
It takes a lot to wire raw metrics all the way through, and the tests suites are broken because manifolds in test suites expect things that aren't there. But it does show up in `juju_metrics`.

I don't think this breaks anything more than it is already broken, but it does wire up a step counter into metrics.


