### PR TITLE
chore: expose metrics to the perf worker

### DIFF
--- a/cmd/jujud-controller/agent/machine.go
+++ b/cmd/jujud-controller/agent/machine.go
@@ -1011,6 +1011,7 @@ func (a *MachineAgent) startModelWorkers(cfg modelworkermanager.NewModelConfig) 
 		NewMigrationMaster:           migrationmaster.NewWorker,
 		ServiceFactory:               cfg.ServiceFactory,
 		ProviderServiceFactoryGetter: cfg.ProviderServiceFactoryGetter,
+		PrometheusRegisterer:         cfg.PrometheusRegisterer,
 	}
 	if wrench.IsActive("charmrevision", "shortinterval") {
 		interval := 10 * time.Second

--- a/cmd/jujud-controller/agent/machine/manifolds.go
+++ b/cmd/jujud-controller/agent/machine/manifolds.go
@@ -714,6 +714,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			Logger:                          internallogger.GetLogger("juju.workers.modelworkermanager"),
 			GetProviderServiceFactoryGetter: modelworkermanager.GetProviderServiceFactoryGetter,
 			GetControllerConfig:             modelworkermanager.GetControllerConfig,
+			PrometheusRegisterer:            config.PrometheusRegisterer,
 		})),
 
 		peergrouperName: ifFullyUpgraded(peergrouper.Manifold(peergrouper.ManifoldConfig{

--- a/cmd/jujud-controller/agent/model/manifolds.go
+++ b/cmd/jujud-controller/agent/model/manifolds.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/utils/v4/voyeur"
 	"github.com/juju/worker/v4"
 	"github.com/juju/worker/v4/dependency"
+	"github.com/prometheus/client_golang/prometheus"
 
 	coreagent "github.com/juju/juju/agent"
 	"github.com/juju/juju/agent/engine"
@@ -127,6 +128,10 @@ type ManifoldsConfig struct {
 
 	// ServiceFactory is used to access the service factory.
 	ServiceFactory servicefactory.ServiceFactory
+
+	// PrometheusRegisterer is a prometheus.Registerer that may be used
+	// by workers to register Prometheus metric collectors.
+	PrometheusRegisterer prometheus.Registerer
 }
 
 // commonManifolds returns a set of interdependent dependency manifolds that will
@@ -157,10 +162,11 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		}),
 
 		perfWorkerName: perf.Manifold(perf.ManifoldConfig{
-			AgentName:          agentName,
-			Clock:              config.Clock,
-			Logger:             config.LoggingContext.GetLogger("juju.worker.perf"),
-			ServiceFactoryName: serviceFactoryName,
+			AgentName:            agentName,
+			Clock:                config.Clock,
+			Logger:               config.LoggingContext.GetLogger("juju.worker.perf"),
+			ServiceFactoryName:   serviceFactoryName,
+			PrometheusRegisterer: config.PrometheusRegisterer,
 		}),
 
 		// The provider service factory is used to access the provider service.

--- a/internal/worker/modelworkermanager/manifold.go
+++ b/internal/worker/modelworkermanager/manifold.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/worker/v4"
 	"github.com/juju/worker/v4/dependency"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/controller"
@@ -64,6 +65,9 @@ type ManifoldConfig struct {
 	ModelMetrics ModelMetrics
 	// Logger is the logger for the worker.
 	Logger logger.Logger
+	// PrometheusRegisterer is a prometheus.Registerer that may be used
+	// by workers to register Prometheus metric collectors.
+	PrometheusRegisterer prometheus.Registerer
 }
 
 // Validate validates the manifold configuration.
@@ -97,6 +101,9 @@ func (config ManifoldConfig) Validate() error {
 	}
 	if config.Logger == nil {
 		return errors.NotValidf("nil Logger")
+	}
+	if config.PrometheusRegisterer == nil {
+		return errors.NotValidf("nil PrometheusRegisterer")
 	}
 	if config.GetProviderServiceFactoryGetter == nil {
 		return errors.NotValidf("nil GetProviderServiceFactoryGetter")
@@ -178,6 +185,7 @@ func (config ManifoldConfig) start(context context.Context, getter dependency.Ge
 		ServiceFactoryGetter:         serviceFactoryGetter,
 		ProviderServiceFactoryGetter: providerServiceFactoryGetter,
 		GetControllerConfig:          config.GetControllerConfig,
+		PrometheusRegisterer:         config.PrometheusRegisterer,
 	})
 	if err != nil {
 		_ = stTracker.Done()

--- a/internal/worker/modelworkermanager/modelworkermanager_test.go
+++ b/internal/worker/modelworkermanager/modelworkermanager_test.go
@@ -209,6 +209,7 @@ func (s *suite) runKillTest(c *gc.C, kill killFunc, test testFunc) {
 		GetControllerConfig: func(ctx context.Context, controllerConfigService modelworkermanager.ControllerConfigService) (controller.Config, error) {
 			return coretesting.FakeControllerConfig(), nil
 		},
+		PrometheusRegisterer: nil,
 	}
 	w, err := modelworkermanager.New(config)
 	c.Assert(err, jc.ErrorIsNil)

--- a/internal/worker/perf/metrics.go
+++ b/internal/worker/perf/metrics.go
@@ -1,0 +1,40 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package perf
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	metricsNamespace   = "juju"
+	subsystemNamespace = "perf"
+)
+
+type Collector struct {
+	iterationCount prometheus.Counter
+}
+
+func NewMetricsCollector() *Collector {
+	// TODO (jam): we could use a CounterVec and do something like counts per model, but for now, we just
+	//  want to know the total count
+	return &Collector{
+		iterationCount: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: subsystemNamespace,
+			Name:      "iteration_count",
+			Help:      "Count the number of iterations that this perf worker has completed",
+		}),
+	}
+}
+
+// Describe is part of the prometheus.Collector interface.
+func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
+	c.iterationCount.Describe(ch)
+}
+
+// Collect is part of the prometheus.Collector interface.
+func (c *Collector) Collect(ch chan<- prometheus.Metric) {
+	c.iterationCount.Collect(ch)
+}

--- a/internal/worker/perf/worker.go
+++ b/internal/worker/perf/worker.go
@@ -23,6 +23,7 @@ type perfWorker struct {
 	runner   *worker.Runner
 	clock    clock.Clock
 	logger   logger.Logger
+	metrics  *Collector
 
 	id int64
 
@@ -30,11 +31,12 @@ type perfWorker struct {
 	service   servicefactory.ServiceFactory
 }
 
-func newPerfWorker(modelUUID model.UUID, service servicefactory.ServiceFactory, clock clock.Clock, logger logger.Logger) (*perfWorker, error) {
+func newPerfWorker(modelUUID model.UUID, service servicefactory.ServiceFactory, clock clock.Clock, logger logger.Logger, metrics *Collector) (*perfWorker, error) {
 	w := &perfWorker{
 		modelUUID: modelUUID,
 		clock:     clock,
 		logger:    logger,
+		metrics:   metrics,
 		service:   service,
 		runner: worker.NewRunner(worker.RunnerParams{
 			Clock: clock,
@@ -121,6 +123,9 @@ func (w *perfWorker) run() error {
 }
 
 func (w *perfWorker) runStep(ctx context.Context, step int) error {
+	// TODO (jam): we could add metrics for the time for each of these calls to complete,
+	//  it might be interesting if one of them is particularly more expensive/slow than the others
+	w.metrics.iterationCount.Inc()
 	switch step % 6 {
 	case 1:
 		// Controller access.


### PR DESCRIPTION
It takes a lot to wire raw metrics all the way through, and the tests suites are broken because manifolds in test suites expect things that aren't there. But it does show up in `juju_metrics`.
