### PR TITLE
Tweak pr 19118

### DIFF
--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -790,7 +790,6 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			Logger:                 loggo.GetLogger("juju.worker.sshserver"),
 			NewServerWrapperWorker: sshserver.NewServerWrapperWorker,
 			NewServerWorker:        sshserver.NewServerWorker,
-			NewSSHServerListener:   sshserver.NewSSHServerListener,
 		})),
 	}
 

--- a/worker/sshserver/manifold.go
+++ b/worker/sshserver/manifold.go
@@ -4,9 +4,6 @@
 package sshserver
 
 import (
-	"net"
-	"time"
-
 	"github.com/juju/errors"
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/dependency"
@@ -42,10 +39,6 @@ type ManifoldConfig struct {
 	// to run the server and other worker dependencies.
 	NewServerWorker func(ServerWorkerConfig) (worker.Worker, error)
 
-	// NewSSHServerListener is the function that creates a listener, based on
-	// an existing listener for the server worker.
-	NewSSHServerListener func(net.Listener, time.Duration) net.Listener
-
 	// Logger is the logger to use for the worker.
 	Logger Logger
 }
@@ -63,9 +56,6 @@ func (config ManifoldConfig) Validate() error {
 	}
 	if config.APICallerName == "" {
 		return errors.NotValidf("empty APICallerName")
-	}
-	if config.NewSSHServerListener == nil {
-		return errors.NotValidf("nil NewSSHServerListener")
 	}
 	return nil
 }
@@ -98,18 +88,12 @@ func (config ManifoldConfig) startWrapperWorker(context dependency.Context) (wor
 	}
 
 	w, err := config.NewServerWrapperWorker(ServerWrapperWorkerConfig{
-		NewServerWorker:      config.NewServerWorker,
-		Logger:               config.Logger,
-		FacadeClient:         client,
-		NewSSHServerListener: config.NewSSHServerListener,
+		NewServerWorker: config.NewServerWorker,
+		Logger:          config.Logger,
+		FacadeClient:    client,
 	})
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	return w, nil
-}
-
-// NewSSHServerListener returns a listener based on the given listener.
-func NewSSHServerListener(l net.Listener, t time.Duration) net.Listener {
-	return l
 }

--- a/worker/sshserver/manifold_test.go
+++ b/worker/sshserver/manifold_test.go
@@ -29,7 +29,6 @@ func newManifoldConfig(l loggo.Logger, modifier func(cfg *sshserver.ManifoldConf
 		NewServerWorker:        func(sshserver.ServerWorkerConfig) (worker.Worker, error) { return nil, nil },
 		Logger:                 l,
 		APICallerName:          "api-caller",
-		NewSSHServerListener:   TestingSSHServerListener,
 	}
 
 	modifier(cfg)
@@ -75,12 +74,6 @@ func (s *manifoldSuite) TestConfigValidate(c *gc.C) {
 		cfg.APICallerName = ""
 	})
 	c.Check(errors.Is(cfg.Validate(), errors.NotValid), jc.IsTrue)
-
-	// Empty NewSSHServerListener.
-	cfg = newManifoldConfig(l, func(cfg *sshserver.ManifoldConfig) {
-		cfg.NewSSHServerListener = nil
-	})
-	c.Check(errors.Is(cfg.Validate(), errors.NotValid), jc.IsTrue)
 }
 
 func (s *manifoldSuite) TestManifoldStart(c *gc.C) {
@@ -90,9 +83,8 @@ func (s *manifoldSuite) TestManifoldStart(c *gc.C) {
 		NewServerWrapperWorker: func(sshserver.ServerWrapperWorkerConfig) (worker.Worker, error) {
 			return workertest.NewDeadWorker(nil), nil
 		},
-		NewServerWorker:      func(sshserver.ServerWorkerConfig) (worker.Worker, error) { return nil, nil },
-		Logger:               loggo.GetLogger("test"),
-		NewSSHServerListener: TestingSSHServerListener,
+		NewServerWorker: func(sshserver.ServerWorkerConfig) (worker.Worker, error) { return nil, nil },
+		Logger:          loggo.GetLogger("test"),
 	})
 
 	// Check the inputs are as expected

--- a/worker/sshserver/server.go
+++ b/worker/sshserver/server.go
@@ -36,9 +36,9 @@ type ServerWorkerConfig struct {
 	// listener this can be left zeroed.
 	Port int
 
-	// NewSSHServerListener is a function that returns a listener and a
+	// TestingSSHServerListener is a function that returns a listener and a
 	// closeAllowed channel.
-	NewSSHServerListener func(net.Listener, time.Duration) net.Listener
+	TestingSSHServerListener func(net.Listener, time.Duration) net.Listener
 }
 
 // Validate validates the workers configuration is as expected.
@@ -48,9 +48,6 @@ func (c ServerWorkerConfig) Validate() error {
 	}
 	if c.JumpHostKey == "" {
 		return errors.NotValidf("empty JumpHostKey")
-	}
-	if c.NewSSHServerListener == nil {
-		return errors.NotValidf("missing NewSSHServerListener")
 	}
 	return nil
 }
@@ -99,7 +96,12 @@ func NewServerWorker(config ServerWorkerConfig) (worker.Worker, error) {
 		s.config.Listener = listener
 	}
 
-	listener := config.NewSSHServerListener(s.config.Listener, time.Second*10)
+	var listener net.Listener
+	if config.TestingSSHServerListener == nil {
+		// make listener
+	} else {
+		listener = config.TestingSSHServerListener(s.config.Listener, time.Second*10)
+	}
 
 	// Start server.
 	s.tomb.Go(func() error {

--- a/worker/sshserver/server_test.go
+++ b/worker/sshserver/server_test.go
@@ -48,9 +48,9 @@ func newServerWorkerConfig(
 	modifier func(*sshserver.ServerWorkerConfig),
 ) *sshserver.ServerWorkerConfig {
 	cfg := &sshserver.ServerWorkerConfig{
-		Logger:               l,
-		JumpHostKey:          j,
-		NewSSHServerListener: TestingSSHServerListener,
+		Logger:                   l,
+		JumpHostKey:              j,
+		TestingSSHServerListener: TestingSSHServerListener,
 	}
 
 	modifier(cfg)
@@ -79,11 +79,6 @@ func (s *sshServerSuite) TestValidate(c *gc.C) {
 	})
 	c.Assert(cfg.Validate(), jc.ErrorIs, errors.NotValid)
 
-	// Test no NewSSHServerListener.
-	cfg = newServerWorkerConfig(l, "NewSSHServerListener", func(cfg *sshserver.ServerWorkerConfig) {
-		cfg.NewSSHServerListener = nil
-	})
-	c.Assert(cfg.Validate(), jc.ErrorIs, errors.NotValid)
 }
 
 func (s *sshServerSuite) TestSSHServer(c *gc.C) {
@@ -94,10 +89,10 @@ func (s *sshServerSuite) TestSSHServer(c *gc.C) {
 	listener := bufconn.Listen(8 * 1024)
 
 	server, err := sshserver.NewServerWorker(sshserver.ServerWorkerConfig{
-		Logger:               loggo.GetLogger("test"),
-		Listener:             listener,
-		JumpHostKey:          jujutesting.SSHServerHostKey,
-		NewSSHServerListener: TestingSSHServerListener,
+		Logger:                   loggo.GetLogger("test"),
+		Listener:                 listener,
+		JumpHostKey:              jujutesting.SSHServerHostKey,
+		TestingSSHServerListener: TestingSSHServerListener,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer workertest.DirtyKill(c, server)

--- a/worker/sshserver/worker.go
+++ b/worker/sshserver/worker.go
@@ -4,9 +4,6 @@
 package sshserver
 
 import (
-	"net"
-	"time"
-
 	"github.com/juju/errors"
 	"github.com/juju/worker/v3"
 	"github.com/juju/worker/v3/catacomb"
@@ -14,10 +11,9 @@ import (
 
 // ServerWrapperWorkerConfig holds the configuration required by the server wrapper worker.
 type ServerWrapperWorkerConfig struct {
-	NewServerWorker      func(ServerWorkerConfig) (worker.Worker, error)
-	Logger               Logger
-	FacadeClient         FacadeClient
-	NewSSHServerListener func(net.Listener, time.Duration) net.Listener
+	NewServerWorker func(ServerWorkerConfig) (worker.Worker, error)
+	Logger          Logger
+	FacadeClient    FacadeClient
 }
 
 // Validate validates the workers configuration is as expected.
@@ -30,9 +26,6 @@ func (c ServerWrapperWorkerConfig) Validate() error {
 	}
 	if c.FacadeClient == nil {
 		return errors.NotValidf("FacadeClient is required")
-	}
-	if c.NewSSHServerListener == nil {
-		return errors.NotValidf("NewSSHServerListener is required")
 	}
 	return nil
 }
@@ -105,10 +98,9 @@ func (ssw *serverWrapperWorker) loop() error {
 	}
 
 	srv, err := ssw.config.NewServerWorker(ServerWorkerConfig{
-		Logger:               ssw.config.Logger,
-		JumpHostKey:          jumpHostKey,
-		Port:                 port,
-		NewSSHServerListener: ssw.config.NewSSHServerListener,
+		Logger:      ssw.config.Logger,
+		JumpHostKey: jumpHostKey,
+		Port:        port,
 	})
 	if err != nil {
 		return errors.Trace(err)

--- a/worker/sshserver/worker_test.go
+++ b/worker/sshserver/worker_test.go
@@ -30,10 +30,9 @@ func newServerWrapperWorkerConfig(
 	modifier func(*sshserver.ServerWrapperWorkerConfig),
 ) *sshserver.ServerWrapperWorkerConfig {
 	cfg := &sshserver.ServerWrapperWorkerConfig{
-		NewServerWorker:      func(sshserver.ServerWorkerConfig) (worker.Worker, error) { return nil, nil },
-		Logger:               l,
-		FacadeClient:         client,
-		NewSSHServerListener: TestingSSHServerListener,
+		NewServerWorker: func(sshserver.ServerWorkerConfig) (worker.Worker, error) { return nil, nil },
+		Logger:          l,
+		FacadeClient:    client,
 	}
 
 	modifier(cfg)
@@ -81,16 +80,6 @@ func (s *workerSuite) TestValidate(c *gc.C) {
 		},
 	)
 	c.Assert(cfg.Validate(), jc.ErrorIs, errors.NotValid)
-
-	// Test no NewSSHServerListener.
-	cfg = newServerWrapperWorkerConfig(
-		l,
-		mockFacadeClient,
-		func(cfg *sshserver.ServerWrapperWorkerConfig) {
-			cfg.NewSSHServerListener = nil
-		},
-	)
-	c.Assert(cfg.Validate(), jc.ErrorIs, errors.NotValid)
 }
 
 func (s *workerSuite) TestSSHServerWrapperWorkerCanBeKilled(c *gc.C) {
@@ -123,7 +112,6 @@ func (s *workerSuite) TestSSHServerWrapperWorkerCanBeKilled(c *gc.C) {
 		NewServerWorker: func(swc sshserver.ServerWorkerConfig) (worker.Worker, error) {
 			return serverWorker, nil
 		},
-		NewSSHServerListener: TestingSSHServerListener,
 	}
 	w, err := sshserver.NewServerWrapperWorker(cfg)
 	c.Assert(err, jc.ErrorIsNil)
@@ -198,7 +186,6 @@ func (s *workerSuite) TestSSHServerWrapperWorkerRestartsServerWorker(c *gc.C) {
 			}
 			return serverWorker, nil
 		},
-		NewSSHServerListener: TestingSSHServerListener,
 	}
 	w, err := sshserver.NewServerWrapperWorker(cfg)
 	c.Assert(err, jc.ErrorIsNil)
@@ -249,7 +236,6 @@ func (s *workerSuite) TestSSHServerWrapperWorkerErrorsOnMissingHostKey(c *gc.C) 
 		NewServerWorker: func(swc sshserver.ServerWorkerConfig) (worker.Worker, error) {
 			return serverWorker, nil
 		},
-		NewSSHServerListener: TestingSSHServerListener,
 	}
 	w1, err := sshserver.NewServerWrapperWorker(cfg)
 	c.Assert(err, gc.IsNil)
@@ -267,7 +253,6 @@ func (s *workerSuite) TestSSHServerWrapperWorkerErrorsOnMissingHostKey(c *gc.C) 
 		NewServerWorker: func(swc sshserver.ServerWorkerConfig) (worker.Worker, error) {
 			return serverWorker, nil
 		},
-		NewSSHServerListener: TestingSSHServerListener,
 	}
 	w2, err := sshserver.NewServerWrapperWorker(cfg)
 	c.Assert(err, gc.IsNil)


### PR DESCRIPTION
Tweaks the pr to not bloat manifold or worker.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!-- 

Describe steps to verify that the change works. 

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-

